### PR TITLE
Add option for short hash length

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,27 @@
 {
-  "name": "grunt-githash",
-  "version": "0.1.3",
+  "name": "grunt-githash-2",
+  "version": "0.2.0",
   "description": "Grunt plugin to get the current git hash, branch and tag",
-  "homepage": "https://github.com/jantimon/grunt-githash",
-  "repository": "https://github.com/jantimon/grunt-githash.git",
+  "homepage": "https://github.com/jasonmccreary/grunt-githash-2",
+  "repository": "https://github.com/jasonmccreary/grunt-githash-2.git",
   "author": {
-    "name": "Jan Nicklas",
-    "email": "j.nicklas@me.com",
-    "url": ""
+    "name": "Jason McCreary",
+    "email": "jason@pureconcepts.net",
+    "url": "https://jason.pureconepts.net"
   },
   "keywords": [
-    "gruntplugin"
+    "gruntplugin",
+    "git"
   ],
   "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.8.0"
   },
   "license": "MIT",
+  "dependencies": {
+    "bluebird": "^3.0.5",
+    "git-rev-2": "^0.1.0"
+  },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-cli": "^0.1.13",
@@ -29,9 +34,5 @@
   },
   "scripts": {
     "test": "grunt test"
-  },
-  "dependencies": {
-    "bluebird": "^3.0.5",
-    "git-rev-2": "^0.1.0"
   }
 }

--- a/tasks/githash.js
+++ b/tasks/githash.js
@@ -20,22 +20,22 @@ module.exports = function (grunt) {
 
     var options = this.options({
       // Break if not inside a git repository
-      fail: true
+      fail: true,
+      length: 7
     });
     var dir = path.resolve(options.dir || '.');
     var done = this.async();
 
     Promise.all([
-      git.shortAsync(dir),
       git.longAsync(dir),
       git.tagAsync(dir),
       git.branchAsync(dir)
       ]).then(function(args){
       return {
-        short: args[0],
-        long: args[1],
-        tag: args[2],
-        branch: args[3]
+        short: args[0].substr(0, options.length),
+        long: args[0],
+        tag: args[1],
+        branch: args[2]
       };
     }).catch(function(err) {
       grunt.log.warn('Could not read git information: ' + err);


### PR DESCRIPTION
The short hash can be different between environments and versions of Git. This can lead to discrepancies when using these values during build. Adding a `length` option (which defaults to 7) provides full control over the length of the short hash.